### PR TITLE
WIP: add a section to download latest TKG-Proton-Build to PGEfast.sh

### DIFF
--- a/updatePGEfast.sh
+++ b/updatePGEfast.sh
@@ -1,24 +1,27 @@
 #!/usr/bin/env bash
-baseuri="https://github.com/GloriousEggroll/proton-ge-custom/releases/download"
-latesturi="https://api.github.com/repos/GloriousEggroll/proton-ge-custom/releases/latest"
+baseuri_ge="https://github.com/GloriousEggroll/proton-ge-custom/releases/download"
+latesturi_ge="https://api.github.com/repos/GloriousEggroll/proton-ge-custom/releases/latest"
+baseuri_tkg="https://github.com/Tk-Glitch/PKGBUILDS/releases/download"
+latesturi_tkg="https://api.github.com/repos/Tk-Glitch/PKGBUILDS/releases/latest"
 dstpath="$HOME/.steam/root/compatibilitytools.d"
 
+### Install latest version of proton-ge ###
 
-  latestversion="$(curl -s $latesturi | egrep -m1 "tag_name" | cut -d \" -f4)"
-  if [[ -d $dstpath/Proton-$latestversion ]]
+  latestversion_ge="$(curl -s $latesturi_ge | egrep -m1 "tag_name" | cut -d \" -f4)"
+  if [[ -d $dstpath/Proton-$latestversion_ge ]]
   then
     echo "Proton $latestversion is the latest version and is already installed."
     echo "Exiting..."
     exit 0
   else
-    echo "Proton $latestversion is the latest version and is not installed yet."
-    echo "Installing Proton $latestverion"
-    url=$(curl -s $latesturi | egrep -m1 "browser_download_url.*Proton" | cut -d \" -f4)
+    echo "Proton $latestversion_ge is the latest version of Proton-GE and is not installed yet."
+    echo "Installing Proton $latestversion_ge"
+    url_ge=$(curl -s $latesturi_ge | egrep -m1 "browser_download_url.*Proton" | cut -d \" -f4)
   fi
 
-rsp="$(curl -sI "$url" | head -1)"
-echo "$rsp" | grep -q 302 || {
-  echo "$rsp"
+rsp_ge="$(curl -sI "$url_ge" | head -1)"
+echo "$rsp_ge" | grep -q 302 || {
+  echo "$rsp_ge"
   exit 1
 }
 
@@ -27,4 +30,35 @@ echo "$rsp" | grep -q 302 || {
     echo [Info] Created "$dstpath"
 }
 
-curl -sL "$url" | tar xfzv - -C "$dstpath"
+curl -sL "$url_ge" | tar xfzv - -C "$dstpath"
+
+### Install latest version of proton-tkg ###
+  latestversion_tkg="$(curl -s $latesturi_tkg | egrep -m1 "tag_name" | cut -d \" -f4)"
+  if [[ -d $dstpath/Proton-TKG-$latestversion_tkg ]]
+  then
+    echo "Proton $latestversion_tkg is the latest version of Proton-TKG and is already installed."
+    echo "Exiting..."
+    exit 0
+  else
+    echo "Proton $latestversion_tkg is the latest version of Proton-TKG and is not installed yet."
+    echo "Installing Proton $latestversion_tkg"
+    url_tkg=$(curl -s $latesturi_tkg | egrep -m1 "browser_download_url.*proton" | cut -d \" -f4)
+  fi
+
+
+rsp_tkg="$(curl -sI "$url_tkg" | head -1)"
+echo "$rsp_tkg" | grep -q 302 || {
+  echo "$rsp_tkg"
+  exit 1
+	}
+
+[ -d "$dstpath" ] || {
+    mkdir "$dstpath"
+    echo [Info] Created "$dstpath"
+	}
+
+#creates a directory for Proton-TKG to be exctracted to, since the .zip-releases of Tk-Glitch don't include such a directory
+mkdir "$HOME/.steam/root/compatibilitytools.d/Proton-TKG-$latestversion_tkg"
+
+#downloads and extracts the lastest release of Proton-TKG. Has be to be done differently since Proton-TKG is packaged as a .zip instead of tar.gz
+wget -q --show-progress "$url_tkg" -O "Proton-TKG-$latestversion_tkg" && unzip -C "Proton-TKG-$latestversion_tkg" -d "$HOME/.steam/root/compatibilitytools.d/Proton-TKG-$latestversion_tkg" && rm "Proton-TKG-$latestversion_tkg"


### PR DESCRIPTION
Hey there, 
I really like the script you created and thought it may be a nice idea to not only install Proton-GE but also install the proton-build from Tk-Glitch (see here: https://github.com/Tk-Glitch/PKGBUILDS/releases/) with that script. They tend to be even more update and also adds some more stuff (as far as I know some special patches)

So I basically just got ahead and added it to the updatePGEfast.sh (since this was easier to edit) and all the stuff needed to download and install the latest release of Proton-TKG. It is not ready for merging just yet but should be at least a good proof of concept. I added and changed a lot variables for this to work correctly. 

Some things I still need some help with since I am not that pro with bash:

- Right now the script will check for updates of GE and after that for TKG. If none of the both is installed, both will be correctly installed. If GE is installed in its most recent version the script will exit and TKG will not be installed even if it is not the most recent version (is not being checked if script ends before it)
- The script may contain some things that are not needed since they are doubled

If you have something else you want to have added please let me know