### PR TITLE
Update cproton.sh to check sha512

### DIFF
--- a/cproton.sh
+++ b/cproton.sh
@@ -1,4 +1,4 @@
- #!/usr/bin/env bash
+#!/usr/bin/env bash
 baseuri="https://github.com/GloriousEggroll/proton-ge-custom/releases/download"
 latesturi="https://api.github.com/repos/GloriousEggroll/proton-ge-custom/releases/latest"
 parameter="${1}"

--- a/cproton.sh
+++ b/cproton.sh
@@ -40,7 +40,7 @@ InstallProtonGE() {
     echo [Info] Created "$dstpath"
   }
   curl -sL "$url" > $dstpath/Proton-"$version".tar.gz # Download archive first
-  if [ ! -z "$sha256url" ]; then # If there is no sha256 the sha256url is empty 
+  if [ ! -z "$sha512url" ]; then # If there is no sha512 the sha512url is empty 
 	if [ $(sha512sum $dstpath/Proton-"$version".tar.gz | cut -b -128) == $((curl -sL $sha512url)| cut -b -128) ]; then # Only the first 128 bytes are significant
 	  tar xfzv $dstpath/Proton-"$version".tar.gz -C "$dstpath"
   	  installComplete=true


### PR DESCRIPTION
Adds sha512 verification, if a .sha512sum file is found. Always downloads the .tar.gz file from the release page, otherwise the addition of the new sha512sums will break the download.