### PR TITLE
Updated updatePGEfast.sh 

### DIFF
--- a/updatePGEfast.sh
+++ b/updatePGEfast.sh
@@ -8,12 +8,16 @@ dstpath="$HOME/.steam/root/compatibilitytools.d"
   if [[ -d $dstpath/Proton-$latestversion ]]
   then
     echo "Proton $latestversion is the latest version and is already installed."
+    sleep 1
     echo "Exiting..."
+    sleep 1
     exit 0
   else
     echo "Proton $latestversion is the latest version and is not installed yet."
-    echo "Installing Proton $latestverion"
-    url=$(curl -s $latesturi | egrep -m1 "browser_download_url.*Proton" | cut -d \" -f4)
+    sleep 3
+    echo "Installing the latest version of Proton now!"
+    sleep 2
+    url=$(curl -s $latesturi | egrep -m1 "browser_download_url.*.tar.gz" | cut -d \" -f4)
   fi
 
 rsp="$(curl -sI "$url" | head -1)"


### PR DESCRIPTION
I removed the checksum verification to make installation faster. As of now, I haven't needed checksum for over a year specifically with PGE, so I found it unnecessary. I also updated the download url to download latest proton config and added timers to allow the user to be able to read the info prompts.

In the future I plan on adding the feature to automatically delete older versions of PGE.