### PR TITLE
Update cproton.sh to reflect name change in files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Script to make it easier to update Proton GE to the latest version.
 Two simple scripts to help you to install the latest version of GloriousEggroll's custom Proton, which can be found [here](https://github.com/GloriousEggroll/proton-ge-custom)
 
 
-[Original script by /u/ChockFullOfShit](https://www.reddit.com/r/SteamPlay/comments/e2ms5v/custom_proton_glorious_eggroll_proton420ge1/f8y2ioe/), I (/u/flubberding) expanded a bit on it.
+[Original script by /u/ChockFullOfShit](https://www.reddit.com/r/SteamPlay/comments/e2ms5v/custom_proton_glorious_eggroll_proton420ge1/f8y2ioe/), further maintained and developed by [/u/flubberding](https://github.com/flubberding) who expanded a bit on it. I now continue on my own repo, because the script was sitting defunctional since many months.
 
-Disclaimer: Subversions like the MCC versions of Proton 4.21-GE-1, will install as it's main version and not install separately.
+Old Disclaimer: Subversions like the MCC versions of Proton 4.21-GE-1, will install as it's main version and not install separately.
 For now, this may result in false "not installed"-detections or errors while force installing a specific subversion.
 
 There are two scripts:

--- a/cproton.sh
+++ b/cproton.sh
@@ -100,7 +100,7 @@ if [ -z "$parameter" ]; then
   version="$(curl -s $latesturi | grep -E -m1 "tag_name" | cut -d \" -f4)"
   url=$(curl -s $latesturi | grep -E -m1 "browser_download_url.*.tar.gz" | cut -d \" -f4)
   sha512url=$(curl -s $latesturi | grep -E -m1 "browser_download_url.*.sha512sum" | cut -d \" -f4)
-  if [ -d "$dstpath"/Proton-"$version" ]; then
+  if [ -d "$dstpath"/"$version" ]; then
     echo "Proton $version is the latest version and is already installed."
   else
     echo "Proton $version is the latest version and is not installed yet."
@@ -108,8 +108,8 @@ if [ -z "$parameter" ]; then
 elif [ "$parameter" == "-l" ]; then
   PrintReleases
 else
-  url=$baseuri/"$parameter"/Proton-"$parameter".tar.gz
-  if [ -d "$dstpath"/Proton-"$parameter" ]; then
+  url=$baseuri/"$parameter"/"$parameter".tar.gz
+  if [ -d "$dstpath"/"$parameter" ]; then
     echo "Proton $parameter is already installed."
   else
     echo "Proton $parameter is not installed yet."


### PR DESCRIPTION
The ProtonGE download path has changed due to a change in the naming of the .tar.gz archives. now the download of older versions should work again. This should address the currently open issue.